### PR TITLE
pass environment through to database sub-module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,7 @@ module "database" {
   count                   = var.skip_rds_creation ? 0 : 1
   source                  = "./modules/database"
   name                    = var.kong_database_config.name
+  environment             = var.environment
   vpc                     = local.vpc_object
   allowed_security_groups = local.security_groups
   database_credentials = { # FIXME: secretes_manager

--- a/modules/database/rds.tf
+++ b/modules/database/rds.tf
@@ -9,12 +9,12 @@ resource "aws_kms_key" "aurora" {
 }
 
 resource "aws_kms_alias" "aurora" {
-  name          = "alias/${var.name}-db-key"
+  name          = "alias/${var.name}-db-key-${var.environment}"
   target_key_id = aws_kms_key.aurora.key_id
 }
 
 resource "aws_rds_cluster" "cluster" {
-  cluster_identifier        = var.name
+  cluster_identifier        = "${var.name}-${var.environment}"
   engine                    = var.database.engine
   engine_version            = var.database.engine_version
   availability_zones        = local.zone_names

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   type        = string
 }
 
+variable "environment" {
+  description = "Resource environment tag (i.e. dev, stage, prod). Used in resource names"
+  type        = string
+  default     = "test"
+}
+
 variable "tags" {
   description = "Tags to apply to aws resources"
   type        = map(string)


### PR DESCRIPTION
use environment name in kms alias and rds cluster
resolves #23

Signed-off-by: Daniel Hill <dan@mamu.co>