### PR TITLE
add lifecycle rules to autoscaling group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -144,6 +144,10 @@ resource "aws_autoscaling_group" "kong" {
   min_size                  = var.asg_min_size
   target_group_arns         = var.target_group_arns
 
+  lifecycle {
+    ignore_changes = [load_balancers, target_group_arns]
+  }
+
   dynamic "tag" {
     for_each = local.tags
     content {


### PR DESCRIPTION
resolves target_group issue when using aws_autoscaling_group with aws_autoscaling_attachment

recommend by Hashicorp:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_attachment