### PR TITLE
Add Kong Launch Configuration to outputs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,7 @@ jobs:
           path: 'repo'
           output_path: 'results.json'
           platform_type: terraform
+          fail_on: high,medium
       - name: Display KICS Results
         run: |
           cat results.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
           fail_on: high,medium
       - name: Display KICS Results
         run: |
-          cat results.json
+          cat results.json/results.json
 
   check-aws-credentials:
     name: Test AWS Credentials

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,12 +37,11 @@ jobs:
         uses: checkmarx/kics-action@v1.2
         with:
           path: 'repo'
-          output_path: 'results'
           platform_type: terraform
           fail_on: high,medium
       - name: Display KICS Results
         run: |
-          cat results/results.json
+          cat /results.json
 
   check-aws-credentials:
     name: Test AWS Credentials

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,12 +37,12 @@ jobs:
         uses: checkmarx/kics-action@v1.2
         with:
           path: 'repo'
-          output_path: 'results.json'
+          output_path: 'results'
           platform_type: terraform
           fail_on: high,medium
       - name: Display KICS Results
         run: |
-          cat results.json/results.json
+          cat results/results.json
 
   check-aws-credentials:
     name: Test AWS Credentials

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,11 +37,12 @@ jobs:
         uses: checkmarx/kics-action@v1.2
         with:
           path: 'repo'
+          output_path: 'results'
           platform_type: terraform
           fail_on: high,medium
       - name: Display KICS Results
         run: |
-          cat results.json
+          cat results/results.json
 
   check-aws-credentials:
     name: Test AWS Credentials

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,7 @@ jobs:
           fail_on: high,medium
       - name: Display KICS Results
         run: |
-          cat /results.json
+          cat results.json
 
   check-aws-credentials:
     name: Test AWS Credentials

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,12 @@ output "asg_outputs" {
   sensitive   = false
 }
 
+output "launch_config_outputs" {
+  value       = aws_launch_configuration.kong
+  description = "Full `aws_launch_configuration` resource details for the launch configuration created for Kong."
+  sensitive   = false
+}
+
 output "private_subnet_azs" {
   value       = local.azs
   description = "List of availability zones used for the private subnets, either supplied in the optional `supplied in the optional `private_subnets` input variable or created in `subnets` submodule` input variable or defined in `subnets` submodule."


### PR DESCRIPTION
It would be useful to be able to access the security groups associated with the kong instances to use, especially in the case of where the Portal is split up, and we want to add a security rule with the `source_security_group_id` corresponding to this value.