### PR TITLE
Update docker run commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,24 +17,24 @@ git-hooks: ## Set up hooks in .githooks
 
 .PHONY: test
 test: ## Build, test, and destroy default scenario with Kitchen Terraform
-	docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test default --destroy=always"
+	docker run --rm -e AWS_PROFILE=default -v $(shell pwd):/usr/action -v ~/.aws:/root/.aws -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ quay.io/dwp/kitchen-terraform:0.14.7 "test default --destroy=always"
 
 .PHONY: test-hybrid-external-database
 test-hybrid-external-database: ## Build, test, and destroy hybrid-external-database scenario with Kitchen Terraform
-	docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test hybrid-external-database --destroy=always"
+	docker run --rm -e AWS_PROFILE=default -v $(shell pwd):/usr/action -v ~/.aws:/root/.aws -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ quay.io/dwp/kitchen-terraform:0.14.7 "test hybrid-external-database --destroy=always"
 
 .PHONY: build
 build: ## Build default scenario with Kitchen Terraform
-	docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test default converge"
+	docker run --rm -e AWS_PROFILE=default -v $(shell pwd):/usr/action -v ~/.aws:/root/.aws -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ quay.io/dwp/kitchen-terraform:0.14.7 "test default converge"
 
 .PHONY: build-hybrid-external-database
 build-hybrid-external-database: ## Test hybrid-external-database scenario with Kitchen Terraform
-	docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "converge hybrid-external-database"
+	docker run --rm -e AWS_PROFILE=default -v $(shell pwd):/usr/action -v ~/.aws:/root/.aws -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ quay.io/dwp/kitchen-terraform:0.14.7 "converge hybrid-external-database"
 
 .PHONY: destroy
 destroy: ## Build default scenario with Kitchen Terraform
-	docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test default destroy"
+	docker run --rm -e AWS_PROFILE=default -v $(shell pwd):/usr/action -v ~/.aws:/root/.aws -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ quay.io/dwp/kitchen-terraform:0.14.7 "test default destroy"
 
 .PHONY: destroy-hybrid-external-database
 destroy-hybrid-external-database: ## Test hybrid-external-database scenario with Kitchen Terraform
-	docker run --rm -e AWS_PROFILE=default -v $(pwd):/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "destroy hybrid-external-database"
+	docker run --rm -e AWS_PROFILE=default -v $(shell pwd):/usr/action -v ~/.aws:/root/.aws -v /etc/ssl/certs/:/usr/local/share/ca-certificates/ quay.io/dwp/kitchen-terraform:0.14.7 "destroy hybrid-external-database"


### PR DESCRIPTION
`$(pwd)` command does not run properly unless the shell is specified inside the brackets.

```
docker run --rm -e AWS_PROFILE=default -v :/usr/action -v ~/.aws:/root/.aws quay.io/dwp/kitchen-terraform:0.14.7 "test default converge"
docker: Error response from daemon: OCI runtime create failed: invalid mount {Destination::/usr/action Type:bind Source:/var/lib/docker/volumes/eb748f4df4bce94423adf319d8c504914763d41c4e62d61d431946cbf2acd087/_data Options:[rbind]}: mount destination :/usr/action not absolute: unknown.
```

Added mount for local certificates, otherwise the following error occurs when running `terraform init` inside the container:

```
Error: Failed to query available provider packages
       
Could not retrieve the list of available versions for provider hashicorp/aws: 
could not connect to registry.terraform.io: 
Failed to request discovery document: Get "https://registry.terraform.io/.well-known/terraform.json":
x509: certificate signed by unknown authority
```