### PR TITLE
chore(examples): correct `pari` typo to `pair`

### DIFF
--- a/examples/hybrid/variables.tf
+++ b/examples/hybrid/variables.tf
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "The name of an AWS ssh key pari to associate with the instances in the ASG"
+  description = "The name of an AWS ssh key pair to associate with the instances in the ASG"
   type        = string
   default     = null
 }

--- a/examples/hybrid_amazon_linux/variables.tf
+++ b/examples/hybrid_amazon_linux/variables.tf
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "The name of an AWS ssh key pari to associate with the instances in the ASG"
+  description = "The name of an AWS ssh key pair to associate with the instances in the ASG"
   type        = string
   default     = null
 }

--- a/examples/hybrid_ecs/variables.tf
+++ b/examples/hybrid_ecs/variables.tf
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "The name of an AWS ssh key pari to associate with the instances in the ASG"
+  description = "The name of an AWS ssh key pair to associate with the instances in the ASG"
   type        = string
   default     = null
 }

--- a/examples/hybrid_external_database/variables.tf
+++ b/examples/hybrid_external_database/variables.tf
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "The name of an AWS ssh key pari to associate with the instances in the ASG"
+  description = "The name of an AWS ssh key pair to associate with the instances in the ASG"
   type        = string
   default     = null
 }

--- a/examples/hybrid_http_proxy/variables.tf
+++ b/examples/hybrid_http_proxy/variables.tf
@@ -10,7 +10,7 @@ variable "instance_type" {
 }
 
 variable "key_name" {
-  description = "The name of an AWS ssh key pari to associate with the instances in the ASG"
+  description = "The name of an AWS ssh key pair to associate with the instances in the ASG"
   type        = string
   default     = null
 }


### PR DESCRIPTION
Signed-off-by: Daniel Hill <dan@mamu.co>