### PR TITLE
feat(ecs): add KONG_PLUGINS variable allowing to load other plugins

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -104,6 +104,7 @@ data "template_file" "kong_task_definition_cp" {
     cluster_cert                = var.cluster_cert
     cluster_key                 = var.cluster_key
     kong_log_level              = var.kong_log_level
+    kong_plugins                = var.kong_plugins
     entrypoint                  = var.entrypoint
     custom_nginx_conf           = base64encode(var.custom_nginx_conf)
   }
@@ -171,6 +172,7 @@ data "template_file" "kong_task_definition_dp" {
     cluster_cert        = var.cluster_cert
     cluster_key         = var.cluster_key
     kong_log_level      = var.kong_log_level
+    kong_plugins        = var.kong_plugins
     entrypoint          = var.entrypoint
     custom_nginx_conf   = base64encode(var.custom_nginx_conf)
   }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -336,3 +336,9 @@ variable "kong_portal_api_url" {
   description = "The Portal API URL of the Portal."
   type        = string
 }
+
+variable "kong_plugins" {
+  description = "Comma-separated list of Kong plugins, passed through the variable KONG_PLUGINS"
+  type        = string
+  default     = "bundled"
+}

--- a/templates/ecs/kong_control_plane.tpl
+++ b/templates/ecs/kong_control_plane.tpl
@@ -116,6 +116,10 @@
       "value": "/usr/local/kong/kong_clustering/cluster.key"
     },
     {
+      "name": "KONG_PLUGINS",
+      "value": "${kong_plugins}"
+    },
+    {
       "name": "KONG_DATABASE",
       "value": "postgres"
     },

--- a/templates/ecs/kong_data_plane.tpl
+++ b/templates/ecs/kong_data_plane.tpl
@@ -82,6 +82,10 @@
       "value": "data_plane"
     },
     {
+      "name": "KONG_PLUGINS",
+      "value": "${kong_plugins}"
+    },
+    {
       "name": "KONG_DATABASE",
       "value": "off"
     },


### PR DESCRIPTION
- Sets `KONG_PLUGINS` with default value as `bundled`.
https://docs.konghq.com/gateway/latest/reference/configuration/#plugins

Signed-off-by: Alvaro Lopez Hernandez <alvaro.lopezhernandez@engineering.digital.dwp.gov.uk>