### PR TITLE
ci: restrict PR workflow from runnning in parallel

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,7 @@
 name: PR
 
+concurrency: pr
+
 on:
   pull_request:
     paths-ignore:


### PR DESCRIPTION
this is to prevent a job starting while another in progress, which currently has two issues: 1) resource name collisions
2) AWS creds get disabled by first job while second job is using them

Signed-off-by: Daniel Hill <dan@mamu.co>