### PR TITLE
fix(ec2): aws_launch_template default version should change as the launch template configuration changes over time

### DIFF
--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -139,11 +139,12 @@ data "template_cloudinit_config" "cloud_init" {
 }
 
 resource "aws_launch_template" "kong" {
-  name_prefix   = local.name
-  image_id      = var.ami_id
-  instance_type = var.instance_type
-  key_name      = var.key_name
-  user_data     = var.user_data == null ? base64encode(data.template_cloudinit_config.cloud_init.rendered) : base64encode(var.user_data)
+  name_prefix            = local.name
+  image_id               = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  user_data              = var.user_data == null ? base64encode(data.template_cloudinit_config.cloud_init.rendered) : base64encode(var.user_data)
+  update_default_version = true
 
   iam_instance_profile {
     name = var.iam_instance_profile_name
@@ -183,7 +184,7 @@ resource "aws_autoscaling_group" "kong" {
 
   launch_template {
     name    = aws_launch_template.kong.name
-    version = "$Latest"
+    version = aws_launch_template.kong.latest_version
   }
 
   desired_capacity          = var.asg_desired_capacity


### PR DESCRIPTION
As a new version of the launch template is created, we want this new version to become the new default launch template for the ASG to use.

Signed-off-by: Alvaro Lopez Hernandez <alvaro.lopezhernandez@engineering.digital.dwp.gov.uk>