### PR TITLE
refactor(ecs): Remove KONG_SSL_CERT and KONG_SSL_CERT_KEY from Portal…

### DIFF
--- a/templates/ecs/kong_control_plane.tpl
+++ b/templates/ecs/kong_control_plane.tpl
@@ -72,14 +72,6 @@
       "value": "/usr/local/kong/kong_clustering/cluster.key"
     },
     {
-      "name": "KONG_SSL_CERT",
-      "value": "/usr/local/kong/ssl/kong.crt"
-    },
-    {
-      "name": "KONG_SSL_CERT_KEY",
-      "value": "/usr/local/kong/ssl/kong.key"
-    },
-    {
       "name": "KONG_ADMIN_LISTEN",
       "value": "0.0.0.0:${admin_api_port} ssl"
     },

--- a/templates/ecs/kong_portal.tpl
+++ b/templates/ecs/kong_portal.tpl
@@ -66,14 +66,6 @@
       "value": "/usr/local/kong/kong_clustering/cluster.key"
     },
     {
-      "name": "KONG_SSL_CERT",
-      "value": "/usr/local/kong/ssl/kong.crt"
-    },
-    {
-      "name": "KONG_SSL_CERT_KEY",
-      "value": "/usr/local/kong/ssl/kong.key"
-    },
-    {
       "name": "KONG_PORTAL_GUI_LISTEN",
       "value": "0.0.0.0:${portal_gui_port} ssl"
     },


### PR DESCRIPTION
… and Control Plane Task Definitions as these aren't needed

Signed-off-by: Matt Holmes <matthew.holmes@engineering.digital.dwp.gov.uk>