### PR TITLE
feat: allow setting Vitals TSDB address

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,7 @@ module "kong_ec2" {
   security_group_name               = var.security_group_name
   kong_vitals_enabled               = var.kong_vitals_enabled
   vitals_endpoint                   = var.vitals_endpoint
+  vitals_tsdb_address               = var.vitals_tsdb_address
 }
 
 
@@ -184,6 +185,7 @@ module "kong_ecs" {
   telemetry_endpoint  = var.telemetry_endpoint
   cluster_server_name = var.cluster_server_name
 
-  vitals_endpoint = var.vitals_endpoint
+  vitals_endpoint     = var.vitals_endpoint
+  vitals_tsdb_address = var.vitals_tsdb_address
 
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -59,6 +59,7 @@ locals {
       clear_database      = var.kong_clear_database
       kong_plugins        = join(",", concat(["bundled"], var.kong_plugins))
       kong_vitals_enabled = var.kong_vitals_enabled
+      vitals_tsdb_address = var.vitals_tsdb_address
       vitals_endpoint = var.vitals_endpoint != null ? format("%s:%g %s",
         var.vitals_endpoint.fqdn,
         var.vitals_endpoint.port,
@@ -87,6 +88,7 @@ locals {
       clear_database      = var.kong_clear_database
       kong_plugins        = join(",", concat(["bundled"], var.kong_plugins))
       kong_vitals_enabled = var.kong_vitals_enabled
+      vitals_tsdb_address = var.vitals_tsdb_address
       vitals_endpoint = var.vitals_endpoint != null ? format("%s:%g %s",
         var.vitals_endpoint.fqdn,
         var.vitals_endpoint.port,

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -594,3 +594,8 @@ variable "vitals_endpoint" {
   })
   default = null
 }
+
+variable "vitals_tsdb_address" {
+  description = "Time series database address for Vitals e.g. my-prometheus.net:9090"
+  type        = string
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -66,6 +66,7 @@ resource "aws_ecs_task_definition" "kong" {
       kong_plugins                = join(",", concat(["bundled"], var.kong_plugins))
       entrypoint                  = var.entrypoint
       nginx_custom_config         = base64encode(var.nginx_custom_config)
+      vitals_tsdb_address         = var.vitals_tsdb_address
       vitals_endpoint = var.vitals_endpoint != null ? format("%s:%g %s",
         var.vitals_endpoint.fqdn,
         var.vitals_endpoint.port,

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -357,3 +357,8 @@ variable "vitals_endpoint" {
   })
   default = null
 }
+
+variable "vitals_tsdb_address" {
+  description = "Time series database address for Vitals e.g. my-prometheus.net:9090"
+  type        = string
+}

--- a/templates/amazon-linux/cloud-init.sh
+++ b/templates/amazon-linux/cloud-init.sh
@@ -402,7 +402,7 @@ KONG_VITALS="on"
 KONG_VITALS_STRATEGY="prometheus"
 KONG_VITALS_STATSD_ADDRESS="${vitals_endpoint}"
 %{ endif }
-KONG_VITALS_TSDB_ADDRESS=127.0.0.1:443
+KONG_VITALS_TSDB_ADDRESS=${vitals_tsdb_address}
 
 %{ for key, value in kong_config ~}
 ${key}="${value}"

--- a/templates/ecs/kong_control_plane.tpl
+++ b/templates/ecs/kong_control_plane.tpl
@@ -179,7 +179,7 @@
     %{ endif }
     {
       "name": "KONG_VITALS_TSDB_ADDRESS",
-      "value": "127.0.0.1:443"
+      "value": "${vitals_tsdb_address}"
     }
   ],
   "secrets": [

--- a/templates/ubuntu/cloud-init.sh
+++ b/templates/ubuntu/cloud-init.sh
@@ -401,6 +401,13 @@ KONG_CLUSTER_TELEMETRY_ENDPOINT="${kong_hybrid_conf.endpoint}:${kong_ports.telem
 
 KONG_PLUGINS="${kong_plugins}"
 
+%{ if vitals_endpoint != "" && kong_vitals_enabled == "on" }
+KONG_VITALS="on"
+KONG_VITALS_STRATEGY="prometheus"
+KONG_VITALS_STATSD_ADDRESS="${vitals_endpoint}"
+%{ endif }
+KONG_VITALS_TSDB_ADDRESS=${vitals_tsdb_address}
+
 %{ for key, value in kong_config ~}
 ${key}="${value}"
 %{ endfor ~}

--- a/variables.tf
+++ b/variables.tf
@@ -845,6 +845,12 @@ variable "vitals_endpoint" {
   default = null
 }
 
+variable "vitals_tsdb_address" {
+  description = "(Optional) Time series database address for Vitals e.g. my-prometheus.net:9090"
+  type        = string
+  default     = "127.0.0.1:443"
+}
+
 variable "kong_plugins" {
   description = "(Optional) List of Kong plugins, passed through the variable KONG_PLUGINS"
   type        = list(string)


### PR DESCRIPTION
Optionally allow user to set Vitals time series database address (e.g. prometheus) as an alternative to Vitals via control plane. See https://docs.konghq.com/gateway/2.8.x/vitals/vitals-prometheus-strategy/#main for further details. Also, added the Vitals endpoint details to Ubuntu cloud-init.sh, which had been missed on previous change