### PR TITLE
fix(githooks): remove dataworks githook

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,103 +51,104 @@ jobs:
         run: |
           cat results/results.json
 
-  docker:
-    name: Docker build and push
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    needs: check-aws-credentials
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to AWS ECR
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-1.amazonaws.com
-          username: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
-          password: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
-      - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: docker-image
-          build-args: 'KONG=2.8.1.1'
-          push: true
-          tags: |
-            ghcr.io/dwp/terraform-aws-kong-gateway:${{ github.run_number }}
-            ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-1.amazonaws.com/terraform-aws-kong-gateway:${{ github.run_number }}
+  ## Commenting until ACTIONS_ACCESS_KEY_ID and ACTIONS_SECRET_ACCESS_KEY are set with a valid set of credentials.
+  #
+  # docker:
+  #   name: Docker build and push
+  #   runs-on: ubuntu-latest
+  #   if: github.event.pull_request.draft == false
+  #   needs: check-aws-credentials
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Login to GitHub Container Registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Login to AWS ECR
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-1.amazonaws.com
+  #         username: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
+  #         password: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+  #     - name: Build and push
+  #       uses: docker/build-push-action@v3
+  #       with:
+  #         context: docker-image
+  #         build-args: 'KONG=2.8.1.1'
+  #         push: true
+  #         tags: |
+  #           ghcr.io/dwp/terraform-aws-kong-gateway:${{ github.run_number }}
+  #           ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-1.amazonaws.com/terraform-aws-kong-gateway:${{ github.run_number }}
 
-  check-aws-credentials:
-    name: Test AWS Credentials
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-      - name: Test AWS Credentials
-        uses: docker://amazon/aws-cli
-        with:
-          args: ec2 describe-availability-zones --region us-east-1
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+  # check-aws-credentials:
+  #   name: Test AWS Credentials
+  #   runs-on: ubuntu-latest
+  #   if: github.event.pull_request.draft == false
+  #   steps:
+  #     - name: Test AWS Credentials
+  #       uses: docker://amazon/aws-cli
+  #       with:
+  #         args: ec2 describe-availability-zones --region us-east-1
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
 
-  test:
-    name: Kitchen-Terraform
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    needs:
-      - check-aws-credentials
-      - docker
-    env:
-      GEMFILE_DIR: .
-      AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
-      TF_VAR_region: eu-west-1
-      TF_VAR_vpc_cidr_block: "10.0.0.0/16"
-      TF_VAR_kong_database_password: ${{ secrets.KONG_DATABASE_PASSWORD }}
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-      - name: Kitchen Test ECS
-        uses: dwp/github-action-kitchen-terraform@v2.0.1
-        with:
-          terraform-version: 0.14.7
-          kitchen-command: test hybrid-ecs --destroy=always
-          aws-account-number: ${{ secrets.AWS_ACCOUNT }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
-          TF_VAR_region: eu-west-1
-          TF_VAR_environment: GHA-${{ github.run_number }}
-          TF_VAR_vpc_cidr_block: "10.0.0.0/16"
-          TF_VAR_kong_database_password: ${{ secrets.KONG_DATABASE_PASSWORD }}
-          TF_VAR_image_url: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-1.amazonaws.com/terraform-aws-kong-gateway:${{ github.run_number }}
-          KONG_EE_LICENSE: ${{ secrets.KONG_EE_LICENSE }}
-      - name: Kitchen Test Amazon Linux 2
-        uses: dwp/github-action-kitchen-terraform@v2.0.1
-        with:
-          terraform-version: 0.14.7
-          kitchen-command: test hybrid-amazon-linux --destroy=always
-          aws-account-number: ${{ secrets.AWS_ACCOUNT }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
-          TF_VAR_region: eu-west-1
-          TF_VAR_environment: GHA-${{ github.run_number }}
-          TF_VAR_vpc_cidr_block: "10.0.0.0/16"
-          TF_VAR_kong_database_password: ${{ secrets.KONG_DATABASE_PASSWORD }}
-      - name: Deactivate AWS Credentials
-        if: ${{ always() }}
-        uses: docker://amazon/aws-cli
-        with:
-          args: iam update-access-key --access-key-id ${{ secrets.ACTIONS_ACCESS_KEY_ID }} --status Inactive
-        env:
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+  # test:
+  #   name: Kitchen-Terraform
+  #   runs-on: ubuntu-latest
+  #   if: github.event.pull_request.draft == false
+  #   needs:
+  #     - check-aws-credentials
+  #     - docker
+  #   env:
+  #     GEMFILE_DIR: .
+  #     AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
+  #     AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+  #     TF_VAR_region: eu-west-1
+  #     TF_VAR_vpc_cidr_block: "10.0.0.0/16"
+  #     TF_VAR_kong_database_password: ${{ secrets.KONG_DATABASE_PASSWORD }}
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v2
+  #     - name: Kitchen Test ECS
+  #       uses: dwp/github-action-kitchen-terraform@v2.0.1
+  #       with:
+  #         terraform-version: 0.14.7
+  #         kitchen-command: test hybrid-ecs --destroy=always
+  #         aws-account-number: ${{ secrets.AWS_ACCOUNT }}
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+  #         TF_VAR_region: eu-west-1
+  #         TF_VAR_environment: GHA-${{ github.run_number }}
+  #         TF_VAR_vpc_cidr_block: "10.0.0.0/16"
+  #         TF_VAR_kong_database_password: ${{ secrets.KONG_DATABASE_PASSWORD }}
+  #         TF_VAR_image_url: ${{ secrets.AWS_ACCOUNT }}.dkr.ecr.eu-west-1.amazonaws.com/terraform-aws-kong-gateway:${{ github.run_number }}
+  #         KONG_EE_LICENSE: ${{ secrets.KONG_EE_LICENSE }}
+  #     - name: Kitchen Test Amazon Linux 2
+  #       uses: dwp/github-action-kitchen-terraform@v2.0.1
+  #       with:
+  #         terraform-version: 0.14.7
+  #         kitchen-command: test hybrid-amazon-linux --destroy=always
+  #         aws-account-number: ${{ secrets.AWS_ACCOUNT }}
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}
+  #         TF_VAR_region: eu-west-1
+  #         TF_VAR_environment: GHA-${{ github.run_number }}
+  #         TF_VAR_vpc_cidr_block: "10.0.0.0/16"
+  #         TF_VAR_kong_database_password: ${{ secrets.KONG_DATABASE_PASSWORD }}
+  #     - name: Deactivate AWS Credentials
+  #       if: ${{ always() }}
+  #       uses: docker://amazon/aws-cli
+  #       with:
+  #         args: iam update-access-key --access-key-id ${{ secrets.ACTIONS_ACCESS_KEY_ID }} --status Inactive
+  #       env:
+  #         AWS_REGION: us-east-1
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.ACTIONS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.ACTIONS_SECRET_ACCESS_KEY }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".githooks"]
-	path = .githooks
-	url = https://github.com/dwp/dataworks-githooks


### PR DESCRIPTION
- Removes dataworks githook reference as this is not needed in this repo.
- Temporarily disables any AWS job from the PR stage until a new set of keys are provided