### PR TITLE
feat(db): add ca certificate field for rds

### DIFF
--- a/modules/database/rds.tf
+++ b/modules/database/rds.tf
@@ -64,6 +64,7 @@ resource "aws_rds_cluster_instance" "cluster" {
   cluster_identifier = aws_rds_cluster.cluster.id
   instance_class     = var.database.instance_type
   apply_immediately  = var.instance_apply_immediately
+  ca_cert_identifier = var.ca_certificate_identifier
   tags               = merge(var.tags, { Name = "${var.name}-db" })
 
   lifecycle {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -88,3 +88,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "ca_certificate_identifier" {
+  description = "(Optional) The CA certificate identifier to use for the DB cluster's server certificate."
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
+}


### PR DESCRIPTION
Changes:
- Update database module to allow specification of CA so users can upgrade through the module
- Set default value of new CA variable to current AWS default: `rds-ca-rsa2048-g1`