### PR TITLE
fix(ecs): vitals env to exist even if set to off

### DIFF
--- a/templates/amazon-linux/cloud-init.sh
+++ b/templates/amazon-linux/cloud-init.sh
@@ -401,12 +401,14 @@ KONG_CLUSTER_TELEMETRY_ENDPOINT="${kong_hybrid_conf.endpoint}:${kong_ports.telem
 
 KONG_PLUGINS="${kong_plugins}"
 
-%{ if vitals_endpoint != "" && kong_vitals_enabled == "on" }
-KONG_VITALS="on"
+KONG_VITALS="${kong_vitals_enabled}"
+%{ if kong_vitals_enabled == "on" }
+%{ if vitals_endpoint != "" }
 KONG_VITALS_STRATEGY="prometheus"
 KONG_VITALS_STATSD_ADDRESS="${vitals_endpoint}"
 %{ endif }
 KONG_VITALS_TSDB_ADDRESS=${vitals_tsdb_address}
+%{ endif }
 
 %{ for key, value in kong_config ~}
 ${key}="${value}"

--- a/templates/ecs/kong_control_plane.tpl
+++ b/templates/ecs/kong_control_plane.tpl
@@ -175,24 +175,26 @@
       "name": "KONG_TRUSTED_IPS",
       "value": "0.0.0.0/0"
     },
-    %{ if vitals_endpoint != "" && kong_vitals_enabled == "on" }
     {
       "name": "KONG_VITALS",
       "value": "${kong_vitals_enabled}"
-    },
-    {
+    }
+    %{ if kong_vitals_enabled == "on" }
+    %{ if vitals_endpoint != "" }
+    ,{
       "name": "KONG_VITALS_STRATEGY",
       "value": "prometheus"
     },
     {
       "name": "KONG_VITALS_STATSD_ADDRESS",
       "value": "${vitals_endpoint}"
-    },
+    }
     %{ endif }
-    {
+    ,{
       "name": "KONG_VITALS_TSDB_ADDRESS",
       "value": "${vitals_tsdb_address}"
     }
+    %{ endif }
     %{ if additional_vars != null }
     %{ for name, value in additional_vars ~}
     ,{

--- a/templates/ecs/kong_data_plane.tpl
+++ b/templates/ecs/kong_data_plane.tpl
@@ -97,24 +97,26 @@
       "name": "KONG_ANONYMOUS_REPORTS",
       "value": "off"
     },
-    %{ if vitals_endpoint != "" && kong_vitals_enabled == "on" }
     {
       "name": "KONG_VITALS",
       "value": "${kong_vitals_enabled}"
-    },
-    {
+    }
+    %{ if kong_vitals_enabled == "on" }
+    %{ if vitals_endpoint != "" }
+    ,{
       "name": "KONG_VITALS_STRATEGY",
       "value": "prometheus"
     },
     {
       "name": "KONG_VITALS_STATSD_ADDRESS",
       "value": "${vitals_endpoint}"
-    },
-    %{ endif }
-    {
-      "name": "KONG_VITALS_TSDB_ADDRESS",
-      "value": "127.0.0.1:443"
     }
+    %{ endif }
+    ,{
+      "name": "KONG_VITALS_TSDB_ADDRESS",
+      "value": "${vitals_tsdb_address}"
+    }
+    %{ endif }
   ],
   "secrets": [
     {

--- a/templates/ubuntu/cloud-init.sh
+++ b/templates/ubuntu/cloud-init.sh
@@ -405,12 +405,14 @@ KONG_CLUSTER_TELEMETRY_ENDPOINT="${kong_hybrid_conf.endpoint}:${kong_ports.telem
 
 KONG_PLUGINS="${kong_plugins}"
 
-%{ if vitals_endpoint != "" && kong_vitals_enabled == "on" }
-KONG_VITALS="on"
+KONG_VITALS="${kong_vitals_enabled}"
+%{ if kong_vitals_enabled == "on" }
+%{ if vitals_endpoint != "" }
 KONG_VITALS_STRATEGY="prometheus"
 KONG_VITALS_STATSD_ADDRESS="${vitals_endpoint}"
 %{ endif }
 KONG_VITALS_TSDB_ADDRESS=${vitals_tsdb_address}
+%{ endif }
 
 %{ for key, value in kong_config ~}
 ${key}="${value}"

--- a/variables.tf
+++ b/variables.tf
@@ -837,6 +837,11 @@ variable "kong_vitals_enabled" {
   description = "(Optional) Define whether or not Kong Vitals should be enabled."
   type        = string
   default     = "on"
+
+  validation {
+    condition     = contains(["on", "off"], var.kong_vitals_enabled)
+    error_message = "Must be one of the following values: 'on' or 'off'."
+  }
 }
 
 variable "kong_portal_enabled" {


### PR DESCRIPTION
Changes:

- Updates vitals logic so `KONG_VITALS` environment variable is always explicitly set even if set to off
- If vitals are turned off, `KONG_VITALS_TSDB_ADDRESS` is also removed (while preserving option for using KONG_VITALS_TSDB_ADDRESS outside of Prometheus integration established in PR #104 
- Add validation so only the two valid options of "on" or "off" can be provided for `KONG_VITALS`